### PR TITLE
Add pipenv install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ To install PyWarp, you can clone the repository and install the required depende
 ```bash
 git clone https://github.com/yourusername/pywarp.git
 cd pywarp
-pipenv install;
-pipenv shell
+./scripts/install.sh
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+scipy
+jupyter
+pytest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+# Simple script to set up the pipenv environment for PyWarp
+
+# Install pipenv if it's not already available
+if ! command -v pipenv >/dev/null 2>&1; then
+    echo "pipenv not found, installing..."
+    pip install --user pipenv
+fi
+
+# Install the project dependencies defined in the Pipfile
+pipenv install --dev
+
+cat <<MSG
+
+Environment is ready. Activate it with:
+  pipenv shell
+MSG
+EOF
+


### PR DESCRIPTION
## Summary
- add helper script `scripts/install.sh` to set up dependencies via pipenv
- document using the script in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*