### PR TITLE
Add test for momentum flow lines

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_get_momentum_flow_lines.py
+++ b/tests/test_get_momentum_flow_lines.py
@@ -11,3 +11,12 @@ def test_get_momentum_flow_lines():
     start_points = [np.array([1, 2, 3]), np.array([1, 2, 3]), np.array([1, 2, 3])]
     step_size = 0.1
     max_steps = 100
+    scale_factor = 1.0
+
+    paths = get_momentum_flow_lines(energy_tensor, start_points, step_size, max_steps, scale_factor)
+    assert len(paths) == 3
+
+    expected_lengths = [82, 72, 62]
+    for path, expected_length in zip(paths, expected_lengths):
+        assert path.shape[0] == expected_length
+        assert not np.isnan(path).any()

--- a/warp/analyzer/get_momentum_flow_lines.py
+++ b/warp/analyzer/get_momentum_flow_lines.py
@@ -38,6 +38,7 @@ def get_momentum_flow_lines(energy_tensor, start_points, step_size, max_steps, s
     for x0, y0, z0 in zip(StrPtsX, StrPtsY, StrPtsZ):
         path = np.zeros((max_steps, 3))
         path[0] = [x0, y0, z0]
+        step_count = 1
 
         for i in range(max_steps - 1):
             pos = path[i]
@@ -45,9 +46,9 @@ def get_momentum_flow_lines(energy_tensor, start_points, step_size, max_steps, s
                 break
 
             # Interpolate the momentum
-            momentum_x = interpolator_x(pos)
-            momentum_y = interpolator_y(pos)
-            momentum_z = interpolator_z(pos)
+            momentum_x = float(interpolator_x(pos))
+            momentum_y = float(interpolator_y(pos))
+            momentum_z = float(interpolator_z(pos))
             momentum = np.array([momentum_x, momentum_y, momentum_z])
 
             if np.any(np.isnan(momentum)):
@@ -55,8 +56,9 @@ def get_momentum_flow_lines(energy_tensor, start_points, step_size, max_steps, s
 
             # Propagate position
             path[i + 1] = pos + momentum * step_size
+            step_count += 1
 
-        paths.append(path[:i + 1])
+        paths.append(path[:step_count])
 
     return paths
 


### PR DESCRIPTION
## Summary
- fix `get_momentum_flow_lines` interpolation and step counting
- ensure repository is importable during tests
- add unit test for `get_momentum_flow_lines`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdd9e49148320b0d8c815d0e1223f