### PR TITLE
Accelerate Ricci loops with Rust

### DIFF
--- a/rust/warp_core/src/lib.rs
+++ b/rust/warp_core/src/lib.rs
@@ -34,8 +34,65 @@ fn c4_inv<'py>(py: Python<'py>, tensor: PyReadonlyArrayDyn<'_, f64>) -> PyResult
     Ok(PyArrayDyn::from_owned_array(py, result))
 }
 
+#[pyfunction]
+fn ricci_t_loops<'py>(py: Python<'py>, diff1: PyReadonlyArrayDyn<'_, f64>, diff2: PyReadonlyArrayDyn<'_, f64>, inv: PyReadonlyArrayDyn<'_, f64>) -> PyResult<&'py PyArrayDyn<f64>> {
+    let diff1 = diff1.as_array();
+    let diff2 = diff2.as_array();
+    let inv = inv.as_array();
+
+    if diff1.ndim() != 4 || diff2.ndim() != 5 || inv.ndim() != 3
+        || diff1.shape()[0] != 4 || diff1.shape()[1] != 4 || diff1.shape()[2] != 4
+        || diff2.shape()[0] != 4 || diff2.shape()[1] != 4 || diff2.shape()[2] != 4 || diff2.shape()[3] != 4
+        || inv.shape()[0] != 4 || inv.shape()[1] != 4
+    {
+        return Err(pyo3::exceptions::PyValueError::new_err("Invalid tensor dimensions"));
+    }
+    let n = diff1.shape()[3];
+    let mut ricci = Array3::<f64>::zeros((4,4,n));
+    for i in 0..4 {
+        for j in i..4 {
+            for idx in 0..n {
+                let mut temp = 0f64;
+                for a in 0..4 {
+                    for b in 0..4 {
+                        temp -= 0.5 * (
+                            diff2[[i,j,a,b,idx]] +
+                            diff2[[a,b,i,j,idx]] -
+                            diff2[[i,b,j,a,idx]] -
+                            diff2[[j,b,i,a,idx]]
+                        ) * inv[[a,b,idx]];
+                    }
+                }
+                for a in 0..4 {
+                    for b in 0..4 {
+                        for c in 0..4 {
+                            for d in 0..4 {
+                                temp += 0.5 * (
+                                    0.5 * diff1[[a,c,i,idx]] * diff1[[b,d,j,idx]] +
+                                    diff1[[i,c,a,idx]] * diff1[[j,d,b,idx]] -
+                                    diff1[[i,c,a,idx]] * diff1[[j,b,d,idx]]
+                                ) * inv[[a,b,idx]] * inv[[c,d,idx]];
+                                temp -= 0.25 * (
+                                    diff1[[j,c,i,idx]] + diff1[[i,c,j,idx]] - diff1[[i,j,c,idx]]
+                                ) * (2.0 * diff1[[b,d,a,idx]] - diff1[[a,b,d,idx]])
+                                    * inv[[a,b,idx]] * inv[[c,d,idx]];
+                            }
+                        }
+                    }
+                }
+                ricci[[i,j,idx]] = temp;
+                if i != j {
+                    ricci[[j,i,idx]] = temp;
+                }
+            }
+        }
+    }
+    Ok(PyArrayDyn::from_owned_array(py, ricci.into_dyn()))
+}
+
 #[pymodule]
 fn warp_core(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(c4_inv, m)?)?;
+    m.add_function(wrap_pyfunction!(ricci_t_loops, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- port `_ricciT_loops` to Rust and expose as `ricci_t_loops`
- call the Rust implementation from `ricciT` when available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408f8aedd88320a99487a94f26a621