### PR TITLE
Expose finite difference operations via Rust

### DIFF
--- a/rust/warp_core/src/lib.rs
+++ b/rust/warp_core/src/lib.rs
@@ -1,5 +1,5 @@
 use ndarray::prelude::*;
-use ndarray::s;
+use ndarray::{s, Zip};
 use pyo3::prelude::*;
 use numpy::{PyReadonlyArrayDyn, PyArrayDyn};
 use nalgebra::Matrix4;
@@ -34,8 +34,70 @@ fn c4_inv<'py>(py: Python<'py>, tensor: PyReadonlyArrayDyn<'_, f64>) -> PyResult
     Ok(PyArrayDyn::from_owned_array(py, result))
 }
 
+fn diff1(arr: &ArrayD<f64>, axis: usize, delta: f64) -> ArrayD<f64> {
+    let mut result = ArrayD::<f64>::zeros(arr.raw_dim());
+    let n = arr.shape()[axis];
+    for i in 0..n {
+        let mut out_slice = result.index_axis_mut(Axis(axis), i);
+        if i == 0 {
+            let next = arr.index_axis(Axis(axis), i + 1);
+            let curr = arr.index_axis(Axis(axis), i);
+            Zip::from(&mut out_slice).and(&next).and(&curr).apply(|o, &nxt, &cur| {
+                *o = (nxt - cur) / delta;
+            });
+        } else if i == n - 1 {
+            let curr = arr.index_axis(Axis(axis), i);
+            let prev = arr.index_axis(Axis(axis), i - 1);
+            Zip::from(&mut out_slice).and(&curr).and(&prev).apply(|o, &cur, &prv| {
+                *o = (cur - prv) / delta;
+            });
+        } else {
+            let next = arr.index_axis(Axis(axis), i + 1);
+            let prev = arr.index_axis(Axis(axis), i - 1);
+            Zip::from(&mut out_slice).and(&next).and(&prev).apply(|o, &nxt, &prv| {
+                *o = (nxt - prv) / (2.0 * delta);
+            });
+        }
+    }
+    result
+}
+
+#[pyfunction]
+fn take_finite_difference1<'py>(
+    py: Python<'py>,
+    tensor: PyReadonlyArrayDyn<'_, f64>,
+    axis: usize,
+    delta: Vec<f64>,
+) -> PyResult<&'py PyArrayDyn<f64>> {
+    let arr = tensor.as_array().to_owned();
+    if axis >= arr.ndim() || axis >= delta.len() {
+        return Err(pyo3::exceptions::PyValueError::new_err("Axis out of range"));
+    }
+    let res = diff1(&arr, axis, delta[axis]);
+    Ok(PyArrayDyn::from_owned_array(py, res))
+}
+
+#[pyfunction]
+fn take_finite_difference2<'py>(
+    py: Python<'py>,
+    tensor: PyReadonlyArrayDyn<'_, f64>,
+    axis1: usize,
+    axis2: usize,
+    delta: Vec<f64>,
+) -> PyResult<&'py PyArrayDyn<f64>> {
+    let arr = tensor.as_array().to_owned();
+    if axis1 >= arr.ndim() || axis2 >= arr.ndim() || axis1 >= delta.len() || axis2 >= delta.len() {
+        return Err(pyo3::exceptions::PyValueError::new_err("Axis out of range"));
+    }
+    let first = diff1(&arr, axis1, delta[axis1]);
+    let second = diff1(&first, axis2, delta[axis2]);
+    Ok(PyArrayDyn::from_owned_array(py, second))
+}
+
 #[pymodule]
 fn warp_core(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(c4_inv, m)?)?;
+    m.add_function(wrap_pyfunction!(take_finite_difference1, m)?)?;
+    m.add_function(wrap_pyfunction!(take_finite_difference2, m)?)?;
     Ok(())
 }

--- a/warp/solver/get_energy_tensor.py
+++ b/warp/solver/get_energy_tensor.py
@@ -3,7 +3,17 @@ from datetime import date
 from numba import njit
 
 try:
-    from warp_core import c4_inv as c4Inv
+    from warp_core import (
+        c4_inv as c4Inv,
+        take_finite_difference1 as _rust_fd1,
+        take_finite_difference2 as _rust_fd2,
+    )
+
+    def takeFiniteDifference1(tensor, axis, delta):
+        return _rust_fd1(tensor, axis, delta)
+
+    def takeFiniteDifference2(tensor, axis1, axis2, delta):
+        return _rust_fd2(tensor, axis1, axis2, delta)
 except Exception:  # fallback to python implementation
     def c4Inv(tensor):
         """Fallback Python implementation of blockwise 4x4 matrix inversion."""
@@ -22,9 +32,9 @@ except Exception:  # fallback to python implementation
         return inv_tensor
 
 
-def takeFiniteDifference1(tensor, axis, delta):
-    """
-    Computes the finite difference (gradient) of a tensor along a specified axis.
+    def takeFiniteDifference1(tensor, axis, delta):
+        """
+        Computes the finite difference (gradient) of a tensor along a specified axis.
 
     Args:
     - tensor (np.ndarray): The input tensor on which to compute the finite difference.
@@ -34,11 +44,11 @@ def takeFiniteDifference1(tensor, axis, delta):
     Returns:
     - np.ndarray: The tensor of finite differences (gradients) along the specified axis.
     """
-    return np.gradient(tensor, delta[axis], axis=axis)
+        return np.gradient(tensor, delta[axis], axis=axis)
 
-def takeFiniteDifference2(tensor, axis1, axis2, delta):
-    """
-    Computes the second-order finite difference (second derivative) of a tensor along two specified axes.
+    def takeFiniteDifference2(tensor, axis1, axis2, delta):
+        """
+        Computes the second-order finite difference (second derivative) of a tensor along two specified axes.
 
     Args:
     - tensor (np.ndarray): The input tensor on which to compute the second-order finite difference.
@@ -49,10 +59,10 @@ def takeFiniteDifference2(tensor, axis1, axis2, delta):
     Returns:
     - np.ndarray: The tensor of second-order finite differences (second derivatives) along the specified axes.
     """
-    if axis1 == axis2:
-        return np.gradient(np.gradient(tensor, delta[axis1], axis=axis1), delta[axis2], axis=axis2)
-    else:
-        return np.gradient(np.gradient(tensor, delta[axis1], axis=axis1), delta[axis2], axis=axis2)
+        if axis1 == axis2:
+            return np.gradient(np.gradient(tensor, delta[axis1], axis=axis1), delta[axis2], axis=axis2)
+        else:
+            return np.gradient(np.gradient(tensor, delta[axis1], axis=axis1), delta[axis2], axis=axis2)
 
 @njit
 def _ricciT_loops(diff1_flat, diff2_flat, inv_flat):


### PR DESCRIPTION
## Summary
- implement `takeFiniteDifference1` and `takeFiniteDifference2` using ndarray in Rust
- expose the new functions through the `warp_core` module
- call Rust finite-difference functions from Python when available

## Testing
- `cargo check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408f885cdc83209b74dfd5f106701d