### PR TITLE
Fix install script and enable maturin builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = [
+    "rust/warp_core",
+    "warp/solver/rust/ricci_core"
+]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ PyWarp is a Python package for calculating the energy tensor from a given metric
 
 ## Installation
 
-To install PyWarp, you can clone the repository and install the required dependencies:
+PyWarp uses a Rust extension built with [maturin](https://github.com/PyO3/maturin).
+The extension is compiled automatically when installing the package via `pip`:
+
+```bash
+pip install .
+```
+
+For development you can still use the helper script which installs the Python
+dependencies using `pipenv`:
 
 ```bash
 git clone https://github.com/yourusername/pywarp.git
@@ -55,12 +63,14 @@ jupyter notebook notebooks/intro.ipynb
 
 ## Building the Rust extension
 
-The `c4_inv` routine is implemented in Rust for improved performance. After
-installing the Python dependencies run:
+The `c4_inv` routine is implemented in Rust for improved performance. When the
+package is installed with `pip` the extension is compiled automatically via the
+`pyproject.toml` configuration. If you need to rebuild the extension while
+developing, run:
 
 ```bash
-pip install maturin
 maturin develop
 ```
 
-This compiles the `warp_core` crate and makes it available to Python.
+This command compiles the `warp_core` crate and installs it into the current
+environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["maturin>=1.4"]
+build-backend = "maturin"
+
+[project]
+name = "pywarp"
+version = "0.1.0"
+description = "Warp drive spacetime tools with Rust extensions"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "PyWarp Developers"}]
+license = {text = "MIT"}
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Rust",
+]
+
+[project.dependencies]
+numpy = "*"
+scipy = "*"
+numba = "*"
+
+[tool.maturin]
+manifest-path = "rust/warp_core/Cargo.toml"
+module-name = "warp_core"
+python-source = "."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,5 +17,4 @@ cat <<MSG
 Environment is ready. Activate it with:
   pipenv shell
 MSG
-EOF
 


### PR DESCRIPTION
## Summary
- remove stray EOF from `scripts/install.sh`
- add `Cargo.toml` workspace and `pyproject.toml` for maturin builds
- document installation and Rust build in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684092b87fec8320aa4999b9d143ab37