### PR TITLE
Add Rust usage tutorial notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ print("Energy Tensor:", energy)
 
 Example notebooks are located in the `notebooks/` directory. Start Jupyter and open
 `intro.ipynb` to see a full workflow that builds a metric, computes its energy tensor
-and visualizes the result using Plotly.
+and visualizes the result using Plotly. The `rust_demo.ipynb` notebook shows the same
+workflow using the Rust extensions for faster linear algebra.
 
 ```bash
 jupyter notebook notebooks/intro.ipynb

--- a/notebooks/rust_demo.ipynb
+++ b/notebooks/rust_demo.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rust-accelerated Energy Tensor\n",
+    "\n",
+    "This notebook shows how to enable the Rust extensions used by PyWarp. After building the extension the energy tensor computations automatically call the Rust routines."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the following once in your environment to compile the extension:" ,
+    "\n",
+    "```bash\n",
+    "pip install maturin\n",
+    "maturin develop\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from warp.metrics.get_alcubierre import metricGet_Alcubierre\n",
+    "from warp.solver.get_energy_tensor import get_energy_tensor\n",
+    "import numpy as np\n",
+    "import plotly.graph_objects as go"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metric = metricGet_Alcubierre([3,4,4,4], [1,2,2,2], 0.1, 1.0, 1.0, [1,1,1,1])\n",
+    "energy = get_energy_tensor(metric)\n",
+    "energy_density = energy['tensor'][0,0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The quantity $T_{00}$ represents the energy density in the chosen coordinates. Regions of negative values would require exotic matter." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.arange(energy_density.shape[1])\n",
+    "y = np.arange(energy_density.shape[2])\n",
+    "X, Y = np.meshgrid(x, y, indexing='ij')\n",
+    "Z = energy_density[1]\n",
+    "fig = go.Figure(data=go.Surface(x=X, y=Y, z=Z))\n",
+    "fig.update_layout(title='Energy Density (T_00)', scene=dict(xaxis_title='x', yaxis_title='y', zaxis_title='T_00'))\n",
+    "fig.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- document a new `rust_demo` Jupyter notebook highlighting the Rust-accelerated routines
- mention the new notebook in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684092b5c8348320842f8555199a9143