### PR TITLE
Add run_parameter_sweep utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ energy = get_energy_tensor(metric, diffOrder='fourth')
 print("Energy Tensor:", energy)
 ```
 
+For sweeps over multiple metrics you can use `run_parameter_sweep` from the `warp.pipeline` module.
+```python
+from warp.pipeline import run_parameter_sweep
+outputs = run_parameter_sweep([metric])
+```
+
 
 Example notebooks are located in the `notebooks/` directory. Start Jupyter and open
 `intro.ipynb` to see a full workflow that builds a metric, computes its energy tensor

--- a/notebooks/intro.ipynb
+++ b/notebooks/intro.ipynb
@@ -72,6 +72,29 @@
     "                  scene=dict(xaxis_title='x', yaxis_title='y', zaxis_title='T_00'))\n",
     "fig.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parameter sweeps\n",
+    "\n",
+    "The `run_parameter_sweep` helper evaluates `eval_metric` for each metric in an iterable and returns all the results as a list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from warp.pipeline.simulation import run_parameter_sweep\n",
+    "from warp.metrics.get_minkowski import metric_get_minkowski\n",
+    "\n",
+    "metrics = [metric_get_minkowski((2,2,2,2)) for _ in range(2)]\n",
+    "results = run_parameter_sweep(metrics)\n",
+    "print(len(results))"
+   ]
   }
  ],
  "metadata": {},

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,15 @@
+import numpy as np
+from warp.pipeline.simulation import run_parameter_sweep
+from warp.metrics.get_minkowski import metric_get_minkowski
+from warp.analyzer.eval_metric import eval_metric
+
+
+def test_run_parameter_sweep():
+    metrics = [metric_get_minkowski((2, 2, 2, 2)) for _ in range(2)]
+    outputs = run_parameter_sweep(metrics)
+    assert isinstance(outputs, list)
+    assert len(outputs) == 2
+
+    expected = [eval_metric(m) for m in metrics]
+    for out, exp in zip(outputs, expected):
+        assert np.allclose(out['energy_tensor']['tensor'], exp['energy_tensor']['tensor'])

--- a/warp/pipeline/__init__.py
+++ b/warp/pipeline/__init__.py
@@ -1,0 +1,1 @@
+from .simulation import run_parameter_sweep

--- a/warp/pipeline/simulation.py
+++ b/warp/pipeline/simulation.py
@@ -1,0 +1,24 @@
+"""Simple simulation utilities for batch metric analysis."""
+
+from typing import Iterable, Dict, Any, List
+
+from warp.analyzer.eval_metric import eval_metric
+
+
+def run_parameter_sweep(metrics: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Evaluate a sequence of metrics using :func:`eval_metric`.
+
+    Parameters
+    ----------
+    metrics : Iterable[dict]
+        Collection of metric dictionaries to evaluate.
+
+    Returns
+    -------
+    list of dict
+        Results from :func:`eval_metric` for each metric in ``metrics``.
+    """
+    results: List[Dict[str, Any]] = []
+    for metric in metrics:
+        results.append(eval_metric(metric))
+    return results


### PR DESCRIPTION
## Summary
- add simulation pipeline module with `run_parameter_sweep`
- document new helper in README and intro notebook
- show basic parameter sweep example in intro notebook
- add unit test for new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840929ff5748320a59d56c45ba8fca6