### PR TITLE
Fix import path in intro notebook

### DIFF
--- a/notebooks/intro.ipynb
+++ b/notebooks/intro.ipynb
@@ -17,6 +17,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os, sys, pathlib\n",
+    "root = pathlib.Path().resolve()\n",
+    "if not (root / 'warp').exists():\n",
+    "    root = root.parent\n",
+    "sys.path.insert(0, str(root))\n",
+    "\n",
     "from warp.metrics.get_alcubierre import metricGet_Alcubierre\n",
     "from warp.solver.get_energy_tensor import get_energy_tensor\n",
     "import plotly.graph_objects as go\n",


### PR DESCRIPTION
## Summary
- ensure `warp` is importable regardless of notebook working directory

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840927eb55083208943a07597c388ba