### PR TITLE
Add visualization example using momentum flow lines

### DIFF
--- a/notebooks/intro.ipynb
+++ b/notebooks/intro.ipynb
@@ -72,6 +72,61 @@
     "                  scene=dict(xaxis_title='x', yaxis_title='y', zaxis_title='T_00'))\n",
     "fig.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24706949",
+   "metadata": {},
+   "source": [
+    "## Visualizing Results\n",
+    "\n",
+    "This section demonstrates how to generate momentum flow lines using `get_momentum_flow_lines` and how to plot kinematic scalars returned by `eval_metric`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e0f2f97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from warp.analyzer.get_momentum_flow_lines import get_momentum_flow_lines\n",
+    "\n",
+    "# choose starting points in the spatial grid\n",
+    "start_points = [np.array([1, 2]), np.array([1, 2]), np.array([1, 2])]\n",
+    "\n",
+    "paths = get_momentum_flow_lines(\n",
+    "    energy['tensor'][:, :, 1],  # use a single time slice\n",
+    "    start_points,\n",
+    "    step_size=0.25,\n",
+    "    max_steps=50,\n",
+    "    scale_factor=0.1\n",
+    ")\n",
+    "\n",
+    "fig = go.Figure()\n",
+    "for path in paths:\n",
+    "    fig.add_trace(go.Scatter3d(x=path[:,0], y=path[:,1], z=path[:,2], mode='lines'))\n",
+    "fig.update_layout(title='Momentum Flow Lines', scene=dict(xaxis_title='x', yaxis_title='y', zaxis_title='z'))\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bf53c89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from warp.analyzer.eval_metric import eval_metric\n",
+    "\n",
+    "results = eval_metric(metric)\n",
+    "expansion = results['expansion'][1]  # middle time slice\n",
+    "fig = go.Figure(data=go.Surface(x=X, y=Y, z=expansion))\n",
+    "fig.update_layout(title='Expansion Scalar', scene=dict(xaxis_title='x', yaxis_title='y', zaxis_title='\\theta'))\n",
+    "fig.show()\n",
+    "\n",
+    "# shear and vorticity can be plotted similarly using results['shear'] and results['vorticity']"
+   ]
   }
  ],
  "metadata": {},


### PR DESCRIPTION
## Summary
- expand intro tutorial notebook with a new *Visualizing Results* section
- demonstrate usage of `get_momentum_flow_lines`
- show how to plot scalars from `eval_metric`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684092a0c3748320b70f389daa05db56