### PR TITLE
Fix import error for Alcubierre metric

### DIFF
--- a/warp/metrics/__init__.py
+++ b/warp/metrics/__init__.py
@@ -1,10 +1,17 @@
 """Metric construction utilities."""
 
-from .get_alcubierre import metric_get_alcubierre, metric_get_alcubierre_comoving
+from .get_alcubierre import (
+    metric_get_alcubierre,
+    metric_get_alcubierre_comoving,
+    metricGet_Alcubierre,
+    metricGet_AlcubierreComoving,
+)
 from .get_minkowski import metric_get_minkowski
 
 __all__ = [
     "metric_get_alcubierre",
     "metric_get_alcubierre_comoving",
+    "metricGet_Alcubierre",
+    "metricGet_AlcubierreComoving",
     "metric_get_minkowski",
 ]

--- a/warp/metrics/get_alcubierre.py
+++ b/warp/metrics/get_alcubierre.py
@@ -38,6 +38,11 @@ def metric_get_alcubierre(gridSize, worldCenter, v, R, sigma, gridScale=(1, 1, 1
 
     return metric
 
+
+def metricGet_Alcubierre(*args, **kwargs):
+    """Backward compatible wrapper for :func:`metric_get_alcubierre`."""
+    return metric_get_alcubierre(*args, **kwargs)
+
 def metric_get_alcubierre_comoving(gridSize, worldCenter, v, R, sigma, gridScale=(1, 1, 1, 1)):
     if gridSize[0] > 1:
         raise ValueError('The time grid is greater than 1, only a size of 1 can be used in comoving')
@@ -74,6 +79,11 @@ def metric_get_alcubierre_comoving(gridSize, worldCenter, v, R, sigma, gridScale
     metric["tensor"] = threePlusOneBuilder(alpha, beta, gamma)
 
     return metric
+
+
+def metricGet_AlcubierreComoving(*args, **kwargs):
+    """Backward compatible wrapper for :func:`metric_get_alcubierre_comoving`."""
+    return metric_get_alcubierre_comoving(*args, **kwargs)
 
 # Define the speed of light constant (in whatever units you're using)
 c = 1  # You may need to adjust this value based on your unit system


### PR DESCRIPTION
## Summary
- expose legacy camelCase helpers for Alcubierre metric
- export these wrappers from `warp.metrics`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ce0afaac83209b98ba7ed78e1289