### PR TITLE
Fix undefined parameter in flow line generator

### DIFF
--- a/warp/analyzer/get_momentum_flow_lines.py
+++ b/warp/analyzer/get_momentum_flow_lines.py
@@ -4,7 +4,16 @@ import warnings
 
 
 
-def get_momentum_flow_lines(energy_tensor, start_points, step_size, max_steps, scale_factor):
+def get_momentum_flow_lines(
+    energy_tensor,
+    start_points,
+    step_size,
+    max_steps,
+    scale_factor,
+    *,
+    momentum_threshold=1e-8,
+    adaptive=False,
+):
     """
     Gets the momentum flow lines for an energy tensor.
     Parameters:


### PR DESCRIPTION
## Summary
- fix undefined variable in `get_momentum_flow_lines`
- expose `momentum_threshold` and `adaptive` keyword arguments

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410e4db75c832087d035f5288b039c