### PR TITLE
Add time evolution simulation helper

### DIFF
--- a/tests/test_time_evolution.py
+++ b/tests/test_time_evolution.py
@@ -1,0 +1,15 @@
+import numpy as np
+from warp.pipeline import run_time_evolution
+from warp.metrics.get_minkowski import metric_get_minkowski
+
+
+def test_run_time_evolution():
+    def metric_fn(t):
+        return metric_get_minkowski((2, 2, 2, 2))
+
+    times = [0.0, 1.0, 2.0]
+    outputs = run_time_evolution(metric_fn, times)
+    assert isinstance(outputs, list)
+    assert len(outputs) == len(times)
+    for out in outputs:
+        assert np.allclose(out['energy_tensor']['tensor'], 0)

--- a/warp/pipeline/__init__.py
+++ b/warp/pipeline/__init__.py
@@ -1,1 +1,2 @@
 from .simulation import run_parameter_sweep
+from .time_evolution import run_time_evolution

--- a/warp/pipeline/time_evolution.py
+++ b/warp/pipeline/time_evolution.py
@@ -1,0 +1,28 @@
+"""Utilities for simple time evolution simulations."""
+
+from typing import Callable, Iterable, Dict, Any, List
+
+from warp.analyzer.eval_metric import eval_metric
+
+
+def run_time_evolution(metric_fn: Callable[[float], Dict[str, Any]], times: Iterable[float]) -> List[Dict[str, Any]]:
+    """Generate metrics for each time in ``times`` using ``metric_fn`` and evaluate them.
+
+    Parameters
+    ----------
+    metric_fn : Callable[[float], dict]
+        Function returning a metric dictionary for a given time value.
+    times : Iterable[float]
+        Sequence of time points to evaluate.
+
+    Returns
+    -------
+    list of dict
+        Results from :func:`eval_metric` for each time step.
+    """
+    results: List[Dict[str, Any]] = []
+    for t in times:
+        metric = metric_fn(t)
+        results.append(eval_metric(metric))
+    return results
+


### PR DESCRIPTION
## Summary
- add `run_time_evolution` to create and evaluate metrics at a series of time points
- expose new function in `warp.pipeline`
- test time evolution helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840dd7620148320ba33ee70346ae377