### PR TITLE
Implement 3+1 scalar calculations

### DIFF
--- a/tests/test_get_scalars.py
+++ b/tests/test_get_scalars.py
@@ -1,6 +1,8 @@
+import numpy as np
 import pytest
 from warp.analyzer.get_scalars import get_scalars
 from warp.core import minkowski_metric
+from warp.metrics.utils import threePlusOneBuilder
 
 def test_get_scalars_error():
     """Ensure get_scalars raises a ValueError for the default Minkowski metric."""
@@ -9,4 +11,21 @@ def test_get_scalars_error():
 
     with pytest.raises(ValueError):
         get_scalars(metric)
+
+
+def test_constant_shift_scalars_zero():
+    """Scalars vanish for Minkowski metric in a boosted frame."""
+    grid_size = (1, 1, 1, 1)
+    alpha = np.ones(grid_size)
+    beta = [np.full(grid_size, 0.5), np.zeros(grid_size), np.zeros(grid_size)]
+    gamma = [np.ones(grid_size), np.ones(grid_size), np.ones(grid_size), np.zeros(grid_size), np.zeros(grid_size), np.zeros(grid_size)]
+
+    tensor = threePlusOneBuilder(alpha, beta, gamma)
+    metric = {"type": "metric", "index": "covariant", "tensor": tensor, "scaling": (1, 1, 1, 1)}
+
+    expansion, shear, vorticity = get_scalars(metric)
+
+    assert np.allclose(expansion, 0)
+    assert np.allclose(shear, 0)
+    assert np.allclose(vorticity, 0)
 

--- a/warp/analyzer/change_tensor_index.py
+++ b/warp/analyzer/change_tensor_index.py
@@ -1,6 +1,18 @@
 import numpy as np
 from typing import Dict, Any, Union
 
+
+def _tensor_inv(tensor: np.ndarray) -> np.ndarray:
+    """Vectorised matrix inverse handling extra spatial dimensions."""
+    if tensor.ndim > 2:
+        shape = tensor.shape[2:]
+        flat = tensor.reshape(4, 4, -1)
+        inv_flat = np.empty_like(flat)
+        for idx in range(flat.shape[-1]):
+            inv_flat[:, :, idx] = np.linalg.inv(flat[:, :, idx])
+        return inv_flat.reshape(4, 4, *shape)
+    return np.linalg.inv(tensor)
+
 def change_tensor_index(input_tensor: Dict[str, Any], index: str, metric_tensor: Union[Dict[str, Any], None] = None) -> Dict[str, Any]:
     """
     Changes a tensor's index.
@@ -30,7 +42,7 @@ def change_tensor_index(input_tensor: Dict[str, Any], index: str, metric_tensor:
     output_tensor = input_tensor.copy()
     if input_tensor['type'].lower() == 'metric':
         if (input_tensor['index'].lower() == 'covariant' and index.lower() == 'contravariant') or (input_tensor['index'].lower() == 'contravariant' and index.lower() == 'covariant'):
-            output_tensor['tensor'] = np.linalg.inv(input_tensor['tensor'])
+            output_tensor['tensor'] = _tensor_inv(input_tensor['tensor'])
         elif input_tensor['index'].lower() in ['mixedupdown', 'mixeddownup']:
             raise ValueError("Input tensor is a Metric tensor of mixed index.")
         elif index.lower() in ['mixedupdown', 'mixeddownup']:
@@ -38,52 +50,52 @@ def change_tensor_index(input_tensor: Dict[str, Any], index: str, metric_tensor:
     else:
         if input_tensor['index'].lower() == 'covariant' and index.lower() == 'contravariant':
             if metric_tensor['index'].lower() == 'covariant':
-                metric_tensor['tensor'] = np.linalg.inv(metric_tensor['tensor'])
+                metric_tensor['tensor'] = _tensor_inv(metric_tensor['tensor'])
                 metric_tensor['index'] = 'contravariant'
             output_tensor['tensor'] = flip_index(input_tensor, metric_tensor)
         elif input_tensor['index'].lower() == 'contravariant' and index.lower() == 'covariant':
             if metric_tensor['index'].lower() == 'contravariant':
-                metric_tensor['tensor'] = np.linalg.inv(metric_tensor['tensor'])
+                metric_tensor['tensor'] = _tensor_inv(metric_tensor['tensor'])
                 metric_tensor['index'] = 'covariant'
             output_tensor['tensor'] = flip_index(input_tensor, metric_tensor)
         elif input_tensor['index'].lower() == 'contravariant' and index.lower() == 'mixedupdown':
             if metric_tensor['index'].lower() == 'contravariant':
-                metric_tensor['tensor'] = np.linalg.inv(metric_tensor['tensor'])
+                metric_tensor['tensor'] = _tensor_inv(metric_tensor['tensor'])
                 metric_tensor['index'] = 'covariant'
             output_tensor['tensor'] = mix_index2(input_tensor, metric_tensor)
         elif input_tensor['index'].lower() == 'contravariant' and index.lower() == 'mixeddownup':
             if metric_tensor['index'].lower() == 'contravariant':
-                metric_tensor['tensor'] = np.linalg.inv(metric_tensor['tensor'])
+                metric_tensor['tensor'] = _tensor_inv(metric_tensor['tensor'])
                 metric_tensor['index'] = 'covariant'
             output_tensor['tensor'] = mix_index1(input_tensor, metric_tensor)
         elif input_tensor['index'].lower() == 'covariant' and index.lower() == 'mixedupdown':
             if metric_tensor['index'].lower() == 'covariant':
-                metric_tensor['tensor'] = np.linalg.inv(metric_tensor['tensor'])
+                metric_tensor['tensor'] = _tensor_inv(metric_tensor['tensor'])
                 metric_tensor['index'] = 'contravariant'
             output_tensor['tensor'] = mix_index1(input_tensor, metric_tensor)
         elif input_tensor['index'].lower() == 'covariant' and index.lower() == 'mixeddownup':
             if metric_tensor['index'].lower() == 'covariant':
-                metric_tensor['tensor'] = np.linalg.inv(metric_tensor['tensor'])
+                metric_tensor['tensor'] = _tensor_inv(metric_tensor['tensor'])
                 metric_tensor['index'] = 'contravariant'
             output_tensor['tensor'] = mix_index2(input_tensor, metric_tensor)
         elif input_tensor['index'].lower() == 'mixedupdown' and index.lower() == 'contravariant':
             if metric_tensor['index'].lower() == 'covariant':
-                metric_tensor['tensor'] = np.linalg.inv(metric_tensor['tensor'])
+                metric_tensor['tensor'] = _tensor_inv(metric_tensor['tensor'])
                 metric_tensor['index'] = 'contravariant'
             output_tensor['tensor'] = mix_index2(input_tensor, metric_tensor)
         elif input_tensor['index'].lower() == 'mixedupdown' and index.lower() == 'covariant':
             if metric_tensor['index'].lower() == 'contravariant':
-                metric_tensor['tensor'] = np.linalg.inv(metric_tensor['tensor'])
+                metric_tensor['tensor'] = _tensor_inv(metric_tensor['tensor'])
                 metric_tensor['index'] = 'covariant'
             output_tensor['tensor'] = mix_index1(input_tensor, metric_tensor)
         elif input_tensor['index'].lower() == 'mixeddownup' and index.lower() == 'covariant':
             if metric_tensor['index'].lower() == 'contravariant':
-                metric_tensor['tensor'] = np.linalg.inv(metric_tensor['tensor'])
+                metric_tensor['tensor'] = _tensor_inv(metric_tensor['tensor'])
                 metric_tensor['index'] = 'covariant'
             output_tensor['tensor'] = mix_index2(input_tensor, metric_tensor)
         elif input_tensor['index'].lower() == 'mixeddownup' and index.lower() == 'contravariant':
             if metric_tensor['index'].lower() == 'covariant':
-                metric_tensor['tensor'] = np.linalg.inv(metric_tensor['tensor'])
+                metric_tensor['tensor'] = _tensor_inv(metric_tensor['tensor'])
                 metric_tensor['index'] = 'contravariant'
             output_tensor['tensor'] = mix_index1(input_tensor, metric_tensor)
 


### PR DESCRIPTION
## Summary
- implement 3+1 decomposition and scalar evaluation
- add vectorised inversion utilities
- adjust change_tensor_index to work with grids
- test scalars for a boosted Minkowski frame

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411b645a9c83208639e38f3e7950e0