### PR TITLE
Refactor inner product utility

### DIFF
--- a/tests/test_get_energy_conditions.py
+++ b/tests/test_get_energy_conditions.py
@@ -1,7 +1,12 @@
 import numpy as np
 import pytest
 from warp.analyzer.get_energy_conditions import get_energy_conditions
-from warp.analyzer.utils import generate_uniform_field, get_even_points_on_sphere, get_inner_product, get_trace
+from warp.analyzer.utils import (
+    generate_uniform_field,
+    get_even_points_on_sphere,
+    get_inner_product,
+    get_trace,
+)
 
 np.random.seed(0)
 
@@ -49,3 +54,21 @@ def test_get_energy_conditions_strong(setup_tensors):
     # metric, energy_tensor = setup_tensors
     # map, vec, vector_field_out = get_energy_conditions(energy_tensor, metric, 'Strong', 100, 10, 0)
     # assert map is not None
+
+
+def test_get_inner_product_consistency():
+    """Ensure shared get_inner_product matches original einsum formulation."""
+    vector1 = {"field": np.random.rand(4, 3, 2)}
+    vector2 = {"field": np.random.rand(4, 3, 2)}
+    metric = {"tensor": np.random.rand(4, 4, 3, 2)}
+
+    expected = np.einsum(
+        "i...,ij...,j...->...",
+        vector1["field"],
+        metric["tensor"],
+        vector2["field"],
+    )
+
+    result = get_inner_product(vector1, vector2, metric)
+    assert np.allclose(result, expected)
+

--- a/warp/analyzer/get_energy_conditions.py
+++ b/warp/analyzer/get_energy_conditions.py
@@ -1,6 +1,13 @@
 from typing import Dict, Any, Tuple, Union
 import numpy as np
-from warp.analyzer.utils import change_tensor_index, generate_uniform_field, get_minkowski_metric, get_trace, do_frame_transfer, get_inner_product
+from warp.analyzer.utils import (
+    change_tensor_index,
+    generate_uniform_field,
+    get_minkowski_metric,
+    get_trace,
+    do_frame_transfer,
+    get_inner_product,
+)
 from warp.solver import verify_tensor
 from warp.metrics.get_minkowski import metric_get_minkowski
 
@@ -94,17 +101,3 @@ def get_energy_conditions(energy_tensor: Dict[str, Any], metric: Dict[str, Any],
                     vec[:, :, :, :, ii, jj] = temp
 
     return map, vec, vec_field if return_vec else None
-
-def get_inner_product(vector1: Dict[str, np.ndarray], vector2: Dict[str, np.ndarray], metric: Dict[str, Any]) -> np.ndarray:
-    """
-    Calculate the inner product of two vectors using the given metric tensor.
-
-    Args:
-        vector1 (dict): First vector.
-        vector2 (dict): Second vector.
-        metric (dict): Metric tensor.
-
-    Returns:
-        np.ndarray: Inner product result.
-    """
-    return np.einsum('i...,ij...,j...->...', vector1['field'], metric['tensor'], vector2['field'])


### PR DESCRIPTION
## Summary
- remove duplicate `get_inner_product` from `get_energy_conditions`
- reimport shared function from `utils`
- test that shared inner product matches old formulation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411b5e3f1c8320918c395c725cfc48