### PR TITLE
Implement Eulerian transformation matrix

### DIFF
--- a/tests/test_eulerian_transform.py
+++ b/tests/test_eulerian_transform.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from warp.analyzer.utils import get_eulerian_transformation_matrix
+
+
+def test_identity_for_minkowski():
+    metric = np.zeros((4, 4))
+    np.fill_diagonal(metric, [-1, 1, 1, 1])
+    M = get_eulerian_transformation_matrix(metric, "cartesian")
+    assert np.allclose(M, np.eye(4))
+
+
+def test_diagonal_metric():
+    diag = [-4.0, 9.0, 16.0, 25.0]
+    metric = np.zeros((4, 4))
+    np.fill_diagonal(metric, diag)
+    M = get_eulerian_transformation_matrix(metric, "cartesian")
+    expected = np.diag([0.5, 1/3, 0.25, 0.2])
+    assert np.allclose(M, expected)
+
+
+def test_unsupported_coords():
+    metric = np.zeros((4, 4))
+    np.fill_diagonal(metric, [-1, 1, 1, 1])
+    with pytest.raises(ValueError):
+        get_eulerian_transformation_matrix(metric, "spherical")

--- a/warp/analyzer/utils.py
+++ b/warp/analyzer/utils.py
@@ -38,9 +38,24 @@ def get_eulerian_transformation_matrix(metric_tensor: np.ndarray, coords: Any) -
     Returns:
         np.ndarray: Eulerian transformation matrix.
     """
-    # Implement the Eulerian transformation matrix logic here
-    # Placeholder implementation for example
-    return np.eye(4)
+    if coords != "cartesian":
+        raise ValueError("Only Cartesian coordinates are supported")
+
+    if metric_tensor.shape[0] != 4 or metric_tensor.shape[1] != 4:
+        raise ValueError("metric_tensor must be a 4x4 tensor")
+
+    # Diagonal components of the metric are used to normalise the tetrad
+    diag = np.diagonal(metric_tensor, axis1=0, axis2=1)
+
+    m_shape = (4, 4) + metric_tensor.shape[2:]
+    transform = np.zeros(m_shape, dtype=metric_tensor.dtype)
+
+    transform[0, 0] = 1.0 / np.sqrt(-diag[0])
+    transform[1, 1] = 1.0 / np.sqrt(diag[1])
+    transform[2, 2] = 1.0 / np.sqrt(diag[2])
+    transform[3, 3] = 1.0 / np.sqrt(diag[3])
+
+    return transform
 
 def get_even_points_on_sphere(num_points: int) -> np.ndarray:
     """


### PR DESCRIPTION
## Summary
- implement real calculation in `get_eulerian_transformation_matrix`
- add unit tests covering identity, diagonal metric, and unsupported coords

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411b56aaa0832082f7909304f029e8