### PR TITLE
Fix utilities and tests, add tasks

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -14,6 +14,10 @@ This document lists tasks for enhancing flow line visualization and the backend 
   - Include visual comparisons of original and improved flow lines.
   - Provide references to relevant sections of the PDF.
 - [x] Validate notebook cells so that example graphs show non-empty trajectories.
+- [ ] Document common errors (e.g. singular matrices) and provide working
+  Alcubierre parameters.
+- [ ] Extend the notebook with a section plotting energy conditions using
+  `plotly` for a valid Alcubierre warp bubble.
 
 ## Miscellaneous
 - [x] Add examples to the README that showcase how to run the notebook and interpret the results.

--- a/tests/test_do_frame_transfer.py
+++ b/tests/test_do_frame_transfer.py
@@ -12,7 +12,7 @@ def setup_tensors():
         'type': 'metric',
         'index': 'covariant',
         'tensor': np.random.rand(4, 4, 4, 4),
-        'coords': None  # Placeholder for actual coordinates
+        'coords': 'cartesian'
     }
     energy_tensor = {
         'type': 'energy',

--- a/warp/analyzer/get_scalars.py
+++ b/warp/analyzer/get_scalars.py
@@ -101,7 +101,7 @@ def get_scalars(metric):
     coords = metric.get('scaling', [1, 1, 1, 1])
 
     del_u_components = np.array([
-        cov_div(metric['tensor'], inv_metric_tensor, u_down, i, j, coords)
+        cov_div(metric['tensor'], inv_metric_tensor, u_up, u_down, i, j, coords)
         for i in range(4) for j in range(4)
     ]).reshape(4, 4, *s)
 


### PR DESCRIPTION
## Summary
- use blockwise inversion in tensor index change
- improve Eulerian transformation matrix broadcasting and stability
- update covariant derivative helper with shape checks and API
- fix tests for do_frame_transfer and get_scalars
- document new notebook tasks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841212321dc8320bf6184d20740d9da