### PR TITLE
Improve energy density visualization

### DIFF
--- a/notebooks/intro.ipynb
+++ b/notebooks/intro.ipynb
@@ -138,8 +138,8 @@
    ],
    "source": [
     "# Extract the energy density (T_00 component)\n",
-    "energy_density = energy['tensor'][0,0]\n",
-    "print(energy_density.shape)"
+    "energy_density_slice = energy['tensor'][0, 0, 1, :, :, 2]\n",
+    "print(energy_density_slice.shape)"
    ]
   },
   {
@@ -971,12 +971,12 @@
    ],
    "source": [
     "# Create coordinate grids for visualisation\n",
-    "x = np.arange(energy_density.shape[1])\n",
-    "t = np.arange(energy_density.shape[0])\n",
-    "X, T = np.meshgrid(x, t, indexing='ij')\n",
-    "Z = energy_density\n",
-    "fig = go.Figure(data=go.Heatmap(x=x, y=t, z=Z))\n",
-    "fig.update_layout(title='Energy Density', xaxis_title='x', yaxis_title='t')\n",
+    "x = np.arange(energy_density_slice.shape[1])\n",
+    "y = np.arange(energy_density_slice.shape[0])\n",
+    "X, Y = np.meshgrid(x, y, indexing='ij')\n",
+    "Z = energy_density_slice\n",
+    "fig = go.Figure(data=go.Heatmap(x=x, y=y, z=Z))\n",
+    "fig.update_layout(title='Energy Density Slice (t=1, z=2)', xaxis_title='x', yaxis_title='y')\n",
     "fig.show()"
    ]
   },


### PR DESCRIPTION
## Summary
- slice energy tensor before plotting to avoid 4D error in intro notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684129bdefe483208fe1bd464fd0c31b