### PR TITLE
Update docs for metrics, units and troubleshooting

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -1,5 +1,7 @@
-# Upcoming Features
+# Features
 
-The project roadmap mirrors the enhancements outlined in `docs/TASKS.md`. New functionality such as improved momentum flow line tracing and additional solver optimizations will be documented here as the implementations land.
+Recent work completed the initial roadmap in `docs/TASKS.md`. Momentum flow line tracing now supports adaptive step sizes and threshold-based termination. The [intro notebook](../notebooks/intro.ipynb) demonstrates these capabilities together with plots of the kinematic scalars.
 
-For now, refer to the PDF `docs/2102.06824v2.pdf` for theoretical background and check the tasks file to track development progress. When a feature is complete the relevant notebook will be updated and referenced from this guide.
+Solver routines were also optimised using a small Rust extension. The resulting speed ups are showcased in [rust_demo.ipynb](../notebooks/rust_demo.ipynb).
+
+Further enhancements are planned; consult `docs/TASKS.md` for details and upcoming milestones.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -3,9 +3,11 @@
 Welcome to the **PyWarp** guide. This section provides an overview of the project and links to the main chapters.
 
 - [Installation](installation.md)
+- [Units and Conventions](units.md)
 - [Available Metrics](metrics.md)
 - [Energy Condition Evaluation](energy_conditions.md)
 - [Example Workflows](workflows.md)
-- [Upcoming Features](features.md)
+- [Features](features.md)
+- [Troubleshooting](troubleshooting.md)
 
 The layout mirrors the structure of the original [WarpFactory GitBook](https://applied-physics.gitbook.io/warp-factory) so users familiar with that resource can easily find equivalent topics.

--- a/docs/guide/metrics.md
+++ b/docs/guide/metrics.md
@@ -4,8 +4,19 @@ PyWarp provides helper functions for common warp-drive metrics. These functions 
 
 | Function | Description |
 |----------|-------------|
-| `warp.core.alcubierre_metric` | Standard Alcubierre spacetime. |
-| `warp.core.alcubierre_comoving_metric` | Alcubierre metric in the comoving frame. |
-| `warp.core.minkowski_metric` | Flat Minkowski metric for reference. |
+| `warp.core.alcubierre_metric` | Builds the canonical Alcubierre warp metric. |
+| `warp.core.alcubierre_comoving_metric` | Alcubierre metric in a comoving frame (time dimension fixed to one). |
+| `warp.core.minkowski_metric` | Flat Minkowski metric used for reference. |
 
 Each function returns a dictionary describing the metric tensor on the simulation grid. The dictionary includes the tensor components, coordinate system, and grid scaling information. See the [notebooks](../notebooks) for concrete examples of constructing metrics.
+
+## Parameters
+
+### `alcubierre_metric`
+`grid_size` defines the `(t, x, y, z)` dimensions while `world_center` sets the bubble centre in grid units. The arguments `v`, `R` and `sigma` control the bubble velocity, radius and wall thickness respectively. Optional `grid_scale` values convert grid indices to physical distances (see [Units and Conventions](units.md)).
+
+### `alcubierre_comoving_metric`
+Accepts the same parameters as `alcubierre_metric` but enforces `grid_size[0] == 1` to produce a single time slice in the comoving frame.
+
+### `minkowski_metric`
+Takes a `grid_size` tuple and an optional `grid_scaling` argument to build a flat spacetime for baseline comparisons.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,0 +1,16 @@
+# Troubleshooting
+
+## Singular matrix errors
+
+Some routines invert the metric tensor and will fail if it becomes singular. If you encounter `ValueError: Metric tensor is singular and cannot be inverted`, reduce the bubble velocity or increase `R` and `sigma` so the grid adequately resolves the warp bubble.
+
+## Recommended Alcubierre parameters
+
+For experimentation the notebooks use:
+
+```python
+from warp.core import alcubierre_metric
+metric = alcubierre_metric((1, 64, 64, 64), (0, 32, 32, 32), v=0.5, R=8, sigma=4)
+```
+
+These values avoid singularities on a 64\^3 grid and work well with the examples in [intro.ipynb](../notebooks/intro.ipynb).

--- a/docs/guide/units.md
+++ b/docs/guide/units.md
@@ -1,0 +1,13 @@
+# Units and Conventions
+
+PyWarp operates in natural units where the speed of light \(c\) is set to one. Time and distance are therefore measured relative to the grid scaling provided when a metric is generated.
+
+## Grid scaling
+
+Each metric generator accepts a `grid_scale` (or `grid_scaling`) argument specifying the spacing along `(t, x, y, z)`. For example `grid_scale=(1, 10, 10, 10)` treats each spatial step as ten times larger than the default.
+
+## Converting to physical units
+
+To convert results to metres and seconds multiply the grid indices by your chosen spatial step and divide or multiply by `c` as required. The constant is defined in `warp.metrics.get_alcubierre` and can be adjusted if you prefer another unit system.
+
+Typical notebooks assume unit spacing which keeps the equations simple. When experimenting with physical scales, ensure that all metric parameters and plotted distances use the same conversion factor.


### PR DESCRIPTION
## Summary
- expand metrics guide with parameter details
- document PyWarp unit conventions
- add troubleshooting notes for singular matrices and sample Alcubierre params
- update features page to link notebooks
- include new pages in guide index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684495361a0883208db2e90bac0592ce