### PR TITLE
Add optional GPU computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ maturin develop
 This command compiles the `warp_core` crate and installs it into the current
 environment. To create a wheel manually you can also run `maturin build`.
 
+## GPU acceleration
+
+Some solver routines can run on a CUDA capable device when
+[CuPy](https://cupy.dev/) is installed. Pass ``try_gpu=1`` to functions such as
+``energy_tensor`` or ``eval_metric`` to enable the GPU kernels. If CuPy is not
+available or no compatible GPU is detected the code automatically falls back to
+NumPy implementations.
+
 ## Testing
 
 The test suite uses `pytest`. After setting up a clean environment and building

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -19,3 +19,10 @@ The Rust extension will compile automatically as part of the installation proces
 ```bash
 maturin develop
 ```
+
+## GPU requirements
+
+GPU acceleration is optional. Install a CuPy build matching your CUDA toolkit,
+e.g. ``pip install cupy-cuda11x``. When available you can enable GPU kernels by
+passing ``try_gpu=1`` to solver functions. If CuPy is not installed or no CUDA
+device is found the CPU implementations are used instead.

--- a/tests/test_get_energy_tensor_gpu.py
+++ b/tests/test_get_energy_tensor_gpu.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pytest
+
+cupy = pytest.importorskip("cupy")  # skip entire module if CuPy not available
+
+from warp.core import minkowski_metric, energy_tensor
+
+
+def test_energy_tensor_gpu_matches_cpu():
+    metric = minkowski_metric((2, 2, 2, 2))
+    cpu_res = energy_tensor(metric, try_gpu=0)
+    gpu_res = energy_tensor(metric, try_gpu=1)
+    assert np.allclose(cpu_res["tensor"], gpu_res["tensor"])
+

--- a/warp/analyzer/eval_metric.py
+++ b/warp/analyzer/eval_metric.py
@@ -26,7 +26,7 @@ def eval_metric(metric: Dict[str, Any], try_gpu: int = 0, keep_positive: int = 1
     output['metric'] = metric
 
     # Energy tensor outputs
-    output['energy_tensor'] = get_energy_tensor(metric)
+    output['energy_tensor'] = get_energy_tensor(metric, try_gpu=try_gpu)
     output['energy_tensor']['type'] = 'energy'
     output['energy_tensor_eulerian'] = do_frame_transfer(metric, output['energy_tensor'], "Eulerian", try_gpu)
 

--- a/warp/core.py
+++ b/warp/core.py
@@ -20,6 +20,16 @@ def minkowski_metric(grid_size, grid_scaling=(1, 1, 1, 1)):
     return metric_get_minkowski(grid_size, grid_scaling)
 
 
-def energy_tensor(metric, diff_order="fourth"):
-    """Compute the stress-energy tensor for *metric*."""
-    return _get_energy_tensor(metric, diffOrder=diff_order)
+def energy_tensor(metric, diff_order="fourth", try_gpu=0):
+    """Compute the stress-energy tensor for *metric*.
+
+    Parameters
+    ----------
+    metric : dict
+        Metric tensor dictionary.
+    diff_order : str, optional
+        Differentiation order, ``"second"`` or ``"fourth"``.
+    try_gpu : int, optional
+        Attempt GPU execution when non-zero and CuPy is available.
+    """
+    return _get_energy_tensor(metric, diffOrder=diff_order, try_gpu=try_gpu)


### PR DESCRIPTION
## Summary
- optionally use CuPy for finite difference and Ricci tensor loops
- plumb `try_gpu` through the public API
- document GPU requirements
- test GPU mode when CuPy is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844963723c4832095246cc03df15feb