### PR TITLE
Add visualizer package with plotting utilities

### DIFF
--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -16,6 +16,16 @@ Typical steps:
    tensor = energy_tensor(metric)
    results = eval_metric(metric)
    ```
-3. Visualize the results with your preferred plotting library.
+3. Visualize the results with the helpers in ``warp.visualizer``:
+   ```python
+   from warp.visualizer import plot_scalar_field, plot_vector_field
+
+   # Energy conditions are returned as scalar fields
+   fig = plot_scalar_field(results["null"], backend="matplotlib")
+
+   # Momentum flow lines are lists of arrays
+   lines = get_momentum_flow_lines(results["energy_tensor"], [...], 0.1, 100, 1.0)
+   fig2 = plot_vector_field(lines, backend="plotly")
+   ```
 
 Additional examples and visualizations will be added once the pending features from `docs/TASKS.md` are implemented.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
 numpy = "*"
 scipy = "*"
 numba = "*"
+matplotlib = "*"
+plotly = "*"
 
 [tool.maturin]
 manifest-path = "rust/warp_core/Cargo.toml"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ scipy
 jupyter
 pytest
 numba
+matplotlib
+plotly

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,0 +1,26 @@
+import numpy as np
+from warp.visualizer import plot_scalar_field, plot_vector_field
+
+
+def test_plot_scalar_field_matplotlib():
+    field = np.random.rand(4, 4, 4)
+    fig = plot_scalar_field(field, backend="matplotlib")
+    assert hasattr(fig, "canvas")
+
+
+def test_plot_scalar_field_plotly():
+    field = np.random.rand(4, 4, 4)
+    fig = plot_scalar_field(field, backend="plotly")
+    assert fig.data
+
+
+def test_plot_vector_field_matplotlib():
+    paths = [np.array([[0, 0, 0], [1, 1, 1]])]
+    fig = plot_vector_field(paths, backend="matplotlib")
+    assert hasattr(fig, "axes")
+
+
+def test_plot_vector_field_plotly():
+    paths = [np.array([[0, 0, 0], [1, 1, 1]])]
+    fig = plot_vector_field(paths, backend="plotly")
+    assert fig.data

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -8,6 +8,7 @@ from .core import (
 )
 
 from .solver import c4Inv
+from .visualizer import plot_tensor, plot_scalar_field, plot_vector_field
 
 __all__ = [
     "alcubierre_metric",
@@ -15,4 +16,8 @@ __all__ = [
     "minkowski_metric",
     "energy_tensor",
     "c4Inv",
+    "plot_tensor",
+    "plot_scalar_field",
+    "plot_vector_field",
 ]
+

--- a/warp/visualizer/__init__.py
+++ b/warp/visualizer/__init__.py
@@ -1,0 +1,6 @@
+"""Visualization helpers for PyWarp."""
+
+from .plot_tensor import plot_tensor, plot_scalar_field, plot_vector_field
+
+__all__ = ["plot_tensor", "plot_scalar_field", "plot_vector_field"]
+

--- a/warp/visualizer/plot_tensor.py
+++ b/warp/visualizer/plot_tensor.py
@@ -1,0 +1,155 @@
+"""Plotting utilities for tensors and fields."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
+
+__all__ = ["plot_tensor", "plot_scalar_field", "plot_vector_field"]
+
+
+def _get_backend(backend: str):
+    backend = backend.lower()
+    if backend == "matplotlib":
+        import matplotlib
+
+        return matplotlib
+    if backend == "plotly":
+        import plotly
+
+        return plotly
+    raise ValueError(f"Unsupported backend: {backend}")
+
+
+def plot_tensor(
+    tensor: np.ndarray,
+    *,
+    component: Optional[Sequence[int]] = None,
+    slice_index: int = 0,
+    backend: str = "matplotlib",
+    title: Optional[str] = None,
+    show: bool = False,
+):
+    """Plot a tensor component using ``matplotlib`` or ``plotly``.
+
+    Parameters
+    ----------
+    tensor:
+        Array representing the tensor. The last three dimensions are interpreted
+        as spatial axes.
+    component:
+        Optional index tuple selecting the tensor component. If ``None`` and the
+        array is 3D, it is treated as a scalar field.
+    slice_index:
+        Index along the z-axis to plot.
+    backend:
+        Either ``"matplotlib"`` or ``"plotly"``.
+    title:
+        Optional plot title.
+    show:
+        If ``True``, display the plot immediately using the chosen backend.
+
+    Returns
+    -------
+    object
+        The figure instance created by the backend.
+    """
+
+    array = np.asarray(tensor)
+    if component is not None:
+        array = array[tuple(component)]
+
+    if array.ndim != 3:
+        raise ValueError("Tensor component must be 3-dimensional")
+
+    data = array[:, :, slice_index]
+    mod = _get_backend(backend)
+
+    if mod.__name__ == "matplotlib":
+        mod.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        im = ax.imshow(data.T, origin="lower")
+        if title:
+            ax.set_title(title)
+        fig.colorbar(im, ax=ax)
+        if show:
+            plt.show()
+        return fig
+
+    if mod.__name__ == "plotly":
+        import plotly.graph_objects as go
+
+        fig = go.Figure(data=go.Heatmap(z=data.T))
+        if title:
+            fig.update_layout(title=title)
+        if show:
+            fig.show()
+        return fig
+
+    raise RuntimeError("Invalid backend")
+
+
+def plot_scalar_field(
+    field: np.ndarray,
+    *,
+    slice_index: int = 0,
+    backend: str = "matplotlib",
+    title: Optional[str] = None,
+    show: bool = False,
+):
+    """Convenience wrapper to plot a scalar field."""
+
+    return plot_tensor(
+        field,
+        component=None,
+        slice_index=slice_index,
+        backend=backend,
+        title=title,
+        show=show,
+    )
+
+
+def plot_vector_field(
+    paths: Iterable[np.ndarray],
+    *,
+    backend: str = "matplotlib",
+    title: Optional[str] = None,
+    show: bool = False,
+):
+    """Plot flow line paths using the chosen backend."""
+
+    mod = _get_backend(backend)
+
+    if mod.__name__ == "matplotlib":
+        mod.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+        for path in paths:
+            ax.plot(path[:, 0], path[:, 1], path[:, 2])
+        if title:
+            ax.set_title(title)
+        if show:
+            plt.show()
+        return fig
+
+    if mod.__name__ == "plotly":
+        import plotly.graph_objects as go
+
+        fig = go.Figure()
+        for path in paths:
+            fig.add_trace(
+                go.Scatter3d(x=path[:, 0], y=path[:, 1], z=path[:, 2], mode="lines")
+            )
+        if title:
+            fig.update_layout(title=title)
+        if show:
+            fig.show()
+        return fig
+
+    raise RuntimeError("Invalid backend")
+


### PR DESCRIPTION
## Summary
- introduce `warp.visualizer` with `plot_tensor`, `plot_scalar_field`, and `plot_vector_field`
- export new plotting helpers from the top-level API
- document plotting workflow in `docs/guide/workflows.md`
- add matplotlib/plotly requirements
- add tests for the plotting helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844953f64b8832080e28acddda58618